### PR TITLE
Added methods to LightweightAssetRepr for getting attribute by label

### DIFF
--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightweightAssetRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightweightAssetRepr.java
@@ -33,4 +33,35 @@ public class LightweightAssetRepr
 		id = a_id;
 		fullAssetUrl = a_fullAssetUrl;
 	}
+
+	public int getNumberOfDisplayAttributesWithLabel(String a_label)
+	{
+		return getDisplayAttributeValuesWithLabel(a_label).size();
+	}
+
+	public boolean hasDisplayAttributeWithLabel(String a_label)
+	{
+		return getNumberOfDisplayAttributesWithLabel(a_label) > 0;
+	}
+
+	public List<String> getDisplayAttributeValuesWithLabel(String a_label)
+	{
+		List<String> values = new ArrayList<String>();
+		for (DisplayAttributeRepr attribute : displayAttributes)
+		{
+			if (attribute.label.equals(a_label))
+			{
+				values.add(attribute.value);
+			}
+		}
+
+		return values;
+	}
+
+	public String getFirstDisplayAttributeValueWithLabel(String a_label)
+	{
+		List<String> values = getDisplayAttributeValuesWithLabel(a_label);
+
+		return values.isEmpty() ? null: values.get(0);
+	}
 }

--- a/src/test/java/com/brightinteractive/assetbank/restapi/representations/LightweightAssetReprTest.java
+++ b/src/test/java/com/brightinteractive/assetbank/restapi/representations/LightweightAssetReprTest.java
@@ -1,0 +1,58 @@
+package com.brightinteractive.assetbank.restapi.representations;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class LightweightAssetReprTest
+{
+	public static final String LABEL = "label";
+	public static final String LABEL_1 = "label1";
+	public static final String VALUE_1 = "value1";
+	public static final String LABEL_2 = "label2";
+	public static final String VALUE_2_A = "value2a";
+	public static final String VALUE_2_B = "value2b";
+
+	LightweightAssetRepr asset;
+
+	@Before
+	public void setup() throws Exception
+	{
+		asset = new LightweightAssetRepr();
+		asset.displayAttributes.add(new DisplayAttributeRepr(LABEL_1, VALUE_1));
+		asset.displayAttributes.add(new DisplayAttributeRepr(LABEL_2, VALUE_2_A));
+		asset.displayAttributes.add(new DisplayAttributeRepr(LABEL_2, VALUE_2_B));
+	}
+
+	@Test
+	public void testGetNumberOfDisplayAttributesWithLabel() throws Exception
+	{
+		assertEquals(0, asset.getNumberOfDisplayAttributesWithLabel(LABEL));
+		assertEquals(1, asset.getNumberOfDisplayAttributesWithLabel(LABEL_1));
+		assertEquals(2, asset.getNumberOfDisplayAttributesWithLabel(LABEL_2));
+	}
+
+	@Test
+	public void testHasDisplayAttributeWithLabel() throws Exception
+	{
+		assertFalse(asset.hasDisplayAttributeWithLabel("label"));
+		assertTrue(asset.hasDisplayAttributeWithLabel(LABEL_1));
+	}
+
+	@Test
+	public void testGetDisplayAttributeValuesWithLabel() throws Exception
+	{
+		List<String> values = asset.getDisplayAttributeValuesWithLabel(LABEL_2);
+		assertTrue(values.contains(VALUE_2_A));
+		assertTrue(values.contains(VALUE_2_B));
+	}
+
+	@Test
+	public void testGetFirstDisplayAttributeValueWithLabel() throws Exception
+	{
+		assertEquals(VALUE_2_A, asset.getFirstDisplayAttributeValueWithLabel(LABEL_2));
+	}
+}


### PR DESCRIPTION
Given that multiple attributes can have the same label rather than start throwing exceptions I thought it was best to make the basic method (getDisplayAttributeValuesWithLabel) return a list of Strings, have a method which returns the first of that list (getFirstDisplayAttributeValueWithLabel) and then methods to check for existence/number of values (hasDisplayAttributeWithLabel & getNumberOfDisplayAttributesWithLabel)

That way it's up to the callers to decided whether they want to check and raise an issue if there are multiple attributes with the same label.
