### PR TITLE
ABC-7736 - Remove old API versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ POJOs used to transfer data to/from Asset Bank via its REST API.
 Prerequisites
 -------------
 
-* Java 1.6
-* Maven (2.2.1 or 3.0.3)
-
+* Java 11
+* Maven 3
 
 Installation
 ------------
@@ -17,8 +16,10 @@ To clone the repo:
 
     git clone git@github.com:brightinteractive/asset-bank-rest-api-reprs.git
 
-To run the project: because this project is a library it cannot be run independently.
+To run the tests:
 
-To run the tests (none yet, so don't be surprised when it reports that 0 tests were run!):
+`mvn test`
 
-	mvn test
+To generate the library as a packaged jar:
+
+`mvn install`

--- a/pom.xml
+++ b/pom.xml
@@ -8,14 +8,14 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>17</source>
-					<target>17</target>
+					<source>11</source>
+					<target>11</target>
 				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.2</version>
 			</plugin>
 		</plugins>
 	</build>
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.15.0</version>
+			<version>2.15.2</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.xml.bind</groupId>
@@ -49,9 +49,14 @@
 			<version>4.0.0</version>
 		</dependency>
 		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.9.2</version>
+			<version>5.10.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetContentUrlRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetContentUrlRepr.java
@@ -1,11 +1,9 @@
 package com.brightinteractive.assetbank.restapi.representations;
 
 import java.net.URL;
-import java.util.List;
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "contentUrl")
 @XmlRootElement(name = "contentUrl")
 public class AssetContentUrlRepr {
   public long assetId;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetEntityAttributeRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetEntityAttributeRepr.java
@@ -4,6 +4,7 @@ package com.brightinteractive.assetbank.restapi.representations;
 import java.net.URL;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "asset-type-attribute")
 @XmlRootElement(name = "asset-type-attribute")
 public class AssetEntityAttributeRepr {
   public AssetEntityAttributeRepr() {

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetEntityRelationshipRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetEntityRelationshipRepr.java
@@ -4,6 +4,7 @@ package com.brightinteractive.assetbank.restapi.representations;
 import java.net.URL;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "asset-type-relationship")
 @XmlRootElement(name = "asset-type-relationship")
 public class AssetEntityRelationshipRepr {
   public AssetEntityRelationshipRepr() {

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetEntityRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetEntityRepr.java
@@ -8,6 +8,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.net.URL;
 import java.util.List;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "asset-type")
 @XmlRootElement(name = "asset-type")
 public class AssetEntityRepr extends LightweightAssetEntityRepr {
   public URL url;
@@ -15,21 +16,27 @@ public class AssetEntityRepr extends LightweightAssetEntityRepr {
   public String includedFileFormats;
   public String excludedFileFormats;
 
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "allowableAttribute")
   @XmlElement(name = "allowableAttribute")
   public List<AssetEntityAttributeRepr> allowableAttributes;
   public boolean showAttributeLabels;
   public URL matchOnAttributeUrl;
 
   public boolean allowChildren;
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "childRelationships")
   @XmlElement(name = "childRelationships")
   public List<AssetEntityRelationshipRepr> childRelationships;
   public String childRelationshipToName;
   public String childRelationshipToNamePlural;
 
   public boolean allowPeers;
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "peerRelationships")
   @XmlElement(name = "peerRelationships")
   public List<AssetEntityRelationshipRepr> peerRelationships;
   public String peerRelationshipToName;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetIdRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetIdRepr.java
@@ -13,6 +13,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "assetId")
 @XmlRootElement(name = "assetId")
 public class AssetIdRepr {
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetInLightboxRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetInLightboxRepr.java
@@ -3,6 +3,7 @@ package com.brightinteractive.assetbank.restapi.representations;
 import java.net.URL;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "assetInLightbox")
 @XmlRootElement(name = "assetInLightbox")
 public class AssetInLightboxRepr {
   public URL assetInstanceUrl;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetRepr.java
@@ -15,6 +15,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "asset")
 @XmlRootElement(name = "asset")
 public class AssetRepr {
   public boolean submitted;
@@ -32,7 +33,9 @@ public class AssetRepr {
   public URL conversionUrl;
   public URL unwatermarkedLargeImageUrl;
 
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "attribute")
   @XmlElement(name = "attribute")
   public List<AttributeValueRepr> attributes;
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/AttributeRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/AttributeRepr.java
@@ -15,6 +15,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "attribute")
 @XmlRootElement(name = "attribute")
 public class AttributeRepr {
   public long id;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/AttributeValueRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/AttributeValueRepr.java
@@ -14,6 +14,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "attributeValue")
 @XmlRootElement(name = "attributeValue")
 public class AttributeValueRepr {
   public Long id;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/BatchContentUrlRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/BatchContentUrlRepr.java
@@ -5,9 +5,12 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "assetContentUrls")
 @XmlRootElement(name = "assetContentUrls")
 public class BatchContentUrlRepr {
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "contentUrl")
   @XmlElement(name = "contentUrl")
   public List<AssetContentUrlRepr> contentUrls;
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/BatchContentUrlRequestRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/BatchContentUrlRequestRepr.java
@@ -1,9 +1,9 @@
 package com.brightinteractive.assetbank.restapi.representations;
 
-import java.net.URL;
 import java.util.List;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "assetIds")
 @XmlRootElement(name = "assetIds")
 public class BatchContentUrlRequestRepr {
   public List<Long> assetIds;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/CategoryRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/CategoryRepr.java
@@ -20,7 +20,9 @@ import jakarta.xml.bind.annotation.XmlSeeAlso;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "category")
 @XmlRootElement(name = "category")
+@javax.xml.bind.annotation.XmlSeeAlso({ CategoryWithCountRepr.class })
 @XmlSeeAlso({ CategoryWithCountRepr.class })
 public class CategoryRepr {
   public URL url;
@@ -29,7 +31,9 @@ public class CategoryRepr {
   public String description;
   public URL parent;
 
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "category")
   @XmlElement(name = "category")
   public Collection<CategoryRepr> children;
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/CategoryWithCountRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/CategoryWithCountRepr.java
@@ -16,6 +16,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "category")
 @XmlRootElement(name = "category")
 public class CategoryWithCountRepr extends CategoryRepr {
   public int count;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/CheckoutRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/CheckoutRepr.java
@@ -16,6 +16,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "checkout")
 @XmlRootElement(name = "checkout")
 public class CheckoutRepr {
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/CreateAssetRequestRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/CreateAssetRequestRepr.java
@@ -18,6 +18,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "createAsset")
 @XmlRootElement(name = "createAsset")
 public class CreateAssetRequestRepr {
   public boolean submit = true;
@@ -25,7 +26,9 @@ public class CreateAssetRequestRepr {
   public long createAsUserId = -1;
   public URL assetTypeUrl;
 
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "accessLevel")
   @XmlElement(name = "accessLevel")
   public List<FolderRepr> accessLevels;
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/CreateAttributeRequestRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/CreateAttributeRequestRepr.java
@@ -5,6 +5,7 @@ package com.brightinteractive.assetbank.restapi.representations;
  */
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "createAttribute")
 @XmlRootElement(name = "createAttribute")
 public class CreateAttributeRequestRepr {
   public long typeId;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/CreateFolderRequestRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/CreateFolderRequestRepr.java
@@ -15,6 +15,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "createAccessLevel")
 @XmlRootElement(name = "createAccessLevel")
 public class CreateFolderRequestRepr {
   public String name;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/DisplayAttributeGroupRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/DisplayAttributeGroupRepr.java
@@ -8,11 +8,14 @@ import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 
+@javax.xml.bind.annotation.XmlRootElement(name = "displayAttributeGroup")
 @XmlRootElement(name = "displayAttributeGroup")
 public class DisplayAttributeGroupRepr {
   public URL url;
 
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "attribute")
   @XmlElement(name = "attribute")
   public List<AttributeRepr> attributes;
   public String name = null;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/DisplayAttributeRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/DisplayAttributeRepr.java
@@ -7,6 +7,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "displayAttribute")
 @XmlRootElement(name = "displayAttribute")
 public class DisplayAttributeRepr {
   public String label = "";

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/EmbeddedDataMappingRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/EmbeddedDataMappingRepr.java
@@ -6,6 +6,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 /**
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "embeddedDataMapping")
 @XmlRootElement(name = "embeddedDataMapping")
 public class EmbeddedDataMappingRepr {
   public URL url;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/FolderRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/FolderRepr.java
@@ -20,7 +20,9 @@ import jakarta.xml.bind.annotation.XmlSeeAlso;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "accessLevel")
 @XmlRootElement(name = "accessLevel")
+@javax.xml.bind.annotation.XmlSeeAlso({ FolderWithCountRepr.class })
 @XmlSeeAlso({ FolderWithCountRepr.class })
 public class FolderRepr {
   public URL url;
@@ -35,7 +37,9 @@ public class FolderRepr {
   public boolean isBrowsable;
   public boolean showPromotedItems;
   public boolean showRecentItems;
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "accessLevel")
   @XmlElement(name = "accessLevel")
   public Collection<FolderRepr> children;
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/FolderWithCountRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/FolderWithCountRepr.java
@@ -14,6 +14,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "accessLevel")
 @XmlRootElement(name = "accessLevel")
 public class FolderWithCountRepr extends FolderRepr {
   public int count;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/KeywordRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/KeywordRepr.java
@@ -11,6 +11,7 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "keyword")
 @XmlRootElement(name = "keyword")
 public class KeywordRepr {
   public URL url;
@@ -19,7 +20,9 @@ public class KeywordRepr {
   public String synonyms;
   public URL parent;
 
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "keyword")
   @XmlElement(name = "keyword")
   public Collection<KeywordRepr> children;
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/KeywordWithCountRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/KeywordWithCountRepr.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
 
+@javax.xml.bind.annotation.XmlRootElement(name = "keyword")
 @XmlRootElement(name = "keyword")
 public class KeywordWithCountRepr extends KeywordRepr {
   public int count;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightboxAssetRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightboxAssetRepr.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.List;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "asset")
 @XmlRootElement(name = "asset")
 public class LightboxAssetRepr extends AssetRepr {
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightboxItemRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightboxItemRepr.java
@@ -15,6 +15,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "lightboxItem")
 @XmlRootElement(name = "lightboxItem")
 public class LightboxItemRepr {
   public long id;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightweightAssetEntityRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightweightAssetEntityRepr.java
@@ -5,6 +5,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 
 import java.net.URL;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "asset-type")
 @XmlRootElement(name = "asset-type")
 public class LightweightAssetEntityRepr {
   public long id;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightweightAssetRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightweightAssetRepr.java
@@ -8,6 +8,7 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "assetSummary")
 @XmlRootElement(name = "assetSummary")
 public class LightweightAssetRepr {
   public long id = 0;
@@ -22,11 +23,15 @@ public class LightweightAssetRepr {
   public String typeName;
   public String accessLevelIds;
 
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "displayAttribute")
   @XmlElement(name = "displayAttribute")
   public List<DisplayAttributeRepr> displayAttributes = new ArrayList<>();
 
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "attribute")
   @XmlElement(name = "attribute")
   public List<SearchAttributeValueRepr> attributes;
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/ListAttributeValueRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/ListAttributeValueRepr.java
@@ -14,6 +14,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "listAttributeValue")
 @XmlRootElement(name = "listAttributeValue")
 public class ListAttributeValueRepr {
   public URL url;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/PendingApprovalRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/PendingApprovalRepr.java
@@ -4,6 +4,7 @@ package com.brightinteractive.assetbank.restapi.representations;
 import java.net.URL;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "pendingApproval")
 @XmlRootElement(name = "pendingApproval")
 public class PendingApprovalRepr {
   public URL assetInstanceUrl;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/PublishedLightboxRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/PublishedLightboxRepr.java
@@ -6,6 +6,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 /**
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "publishedLightbox")
 @XmlRootElement(name = "publishedLightbox")
 public class PublishedLightboxRepr {
   public URL publishedLightboxUrl;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/PublishingActionIdRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/PublishingActionIdRepr.java
@@ -18,6 +18,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "publishingActionId")
 @XmlRootElement(name = "publishingActionId")
 public class PublishingActionIdRepr {
   public long publishingActionId;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/PublishingActionRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/PublishingActionRepr.java
@@ -12,6 +12,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "publishingAction")
 @XmlRootElement(name = "publishingAction")
 public class PublishingActionRepr {
   public String name;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/PublishingLogRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/PublishingLogRepr.java
@@ -14,6 +14,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "publishingLog")
 @XmlRootElement(name = "publishingLog")
 public class PublishingLogRepr {
   @SuppressWarnings("unused")
@@ -25,7 +26,9 @@ public class PublishingLogRepr {
     nextStartSequence = a_nextStartSequence;
   }
 
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "event")
   @XmlElement(name = "event")
   public List<PublishingEventRepr> events;
   public long nextStartSequence;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/ResourceRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/ResourceRepr.java
@@ -8,7 +8,9 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlValue;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "resource")
 @XmlRootElement(name = "resource")
+@javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.NONE)
 @XmlAccessorType(XmlAccessType.NONE)
 public class ResourceRepr {
   private String resource;
@@ -24,6 +26,7 @@ public class ResourceRepr {
     this(resourceURL.toString());
   }
 
+  @javax.xml.bind.annotation.XmlValue
   @XmlValue
   @JsonValue
   public String getResource() {

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/RootRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/RootRepr.java
@@ -25,6 +25,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "root")
 @XmlRootElement(name = "root")
 public class RootRepr {
   private static String API_NAME = "AssetBank RESTful API";

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/RootRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/RootRepr.java
@@ -11,7 +11,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  * <p>
  * {
  * "api_name": "AssetBank RESTful API"
- * "api_version_1_1": {
+ * "api_version_1_3": {
  * "checkoutUrl": "http://..."
  * "lightboxesUrl": "http://..."
  * "assetsUrl": "http://..."
@@ -29,28 +29,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "root")
 public class RootRepr {
   private static String API_NAME = "AssetBank RESTful API";
-
-  public static class RootServices_v_1_1 {
-    public URL checkoutUrl;
-    public URL lightboxesUrl;
-    public URL assetsUrl;
-    public URL signingUrl;
-  }
-
-  public static class RootServices_v_1_2 {
-    public URL checkoutUrl;
-    public URL lightboxesUrl;
-    public URL assetsUrl;
-    public URL usersUrl;
-    public URL userSearchUrl;
-    public URL attributesUrl;
-    public URL categorySearchUrl;
-    public URL accessLevelSearchUrl;
-    public URL signingUrl;
-    public URL assetSearchUrl;
-    public URL publishingActionsUrl;
-    public URL displayAttributeGroupUrl;
-  }
 
   public static class RootServices_v_1_3 {
     public URL checkoutUrl;
@@ -76,8 +54,6 @@ public class RootRepr {
   }
 
   public String api_name;
-  public RootServices_v_1_1 api_version_1_1;
-  public RootServices_v_1_2 api_version_1_2;
   public RootServices_v_1_3 api_version_1_3;
   public static final String LATEST_API_VERSION = "api_version_1_3";
 
@@ -87,9 +63,7 @@ public class RootRepr {
 
   public RootRepr(URL checkoutUrl,
       URL lightboxesUrl,
-      URL lightboxes_v1_1_Url,
       URL assetsUrl,
-      URL assets_v1_2_Url,
       URL usersUrl,
       URL userSearchUrl,
       URL attributesUrl,
@@ -108,30 +82,6 @@ public class RootRepr {
       URL authenticatedUserUrl,
       URL embeddedDataMappingsUrl) {
     api_name = API_NAME;
-
-    //build the 1.1 version...
-    api_version_1_1 = new RootServices_v_1_1();
-    api_version_1_1.checkoutUrl = checkoutUrl;
-    api_version_1_1.lightboxesUrl = lightboxes_v1_1_Url;
-    api_version_1_1.assetsUrl = assets_v1_2_Url;
-    api_version_1_1.signingUrl = signingUrl;
-
-    //and now the 1.2...
-    api_version_1_2 = new RootServices_v_1_2();
-    api_version_1_2.checkoutUrl = checkoutUrl;
-    api_version_1_2.lightboxesUrl = lightboxesUrl;
-    api_version_1_2.assetsUrl = assets_v1_2_Url;
-    api_version_1_2.usersUrl = usersUrl;
-    api_version_1_2.userSearchUrl = userSearchUrl;
-    api_version_1_2.attributesUrl = attributesUrl;
-    api_version_1_2.categorySearchUrl = categorySearchUrl;
-    api_version_1_2.accessLevelSearchUrl = folderSearchUrl;
-    api_version_1_2.signingUrl = signingUrl;
-    api_version_1_2.assetSearchUrl = assetSearchUrl;
-    api_version_1_2.publishingActionsUrl = publishingActionsUrl;
-    api_version_1_2.displayAttributeGroupUrl = displayAttributeGroupUrl;
-
-    //and now the 1.3...
     api_version_1_3 = new RootServices_v_1_3();
     api_version_1_3.checkoutUrl = checkoutUrl;
     api_version_1_3.lightboxesUrl = lightboxesUrl;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/SaveStatusRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/SaveStatusRepr.java
@@ -17,6 +17,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "saveStatus")
 @XmlRootElement(name = "saveStatus")
 public class SaveStatusRepr {
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/SearchAttributeValueRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/SearchAttributeValueRepr.java
@@ -2,6 +2,7 @@ package com.brightinteractive.assetbank.restapi.representations;
 
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+@javax.xml.bind.annotation.XmlRootElement(name = "attribute")
 @XmlRootElement(name = "attribute")
 public class SearchAttributeValueRepr {
   public String name;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/SignedURLRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/SignedURLRepr.java
@@ -8,6 +8,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "signedURL")
 @XmlRootElement(name = "signedURL")
 public class SignedURLRepr {
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/UserIdRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/UserIdRepr.java
@@ -12,6 +12,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "userId")
 @XmlRootElement(name = "userId")
 public class UserIdRepr {
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/UserRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/UserRepr.java
@@ -19,6 +19,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  *
  * @author Bright
  */
+@javax.xml.bind.annotation.XmlRootElement(name = "user")
 @XmlRootElement(name = "user")
 public class UserRepr {
   public URL url;
@@ -28,7 +29,9 @@ public class UserRepr {
   public String forename = null;
   public String surname = null;
   public String emailAddress = null;
+  @javax.xml.bind.annotation.XmlElementWrapper
   @XmlElementWrapper
+  @javax.xml.bind.annotation.XmlElement(name = "groupId")
   @XmlElement(name = "groupId")
   public Collection<Long> groupIds = null;
   public boolean isAdmin = false;


### PR DESCRIPTION
This includes a change to make this lib work with both javax and jakarta namespaces. Some context:

A few months ago, as part of the vulnerability fixes, I upgraded some dependencies in this library and migrated it from the javax namespace to jakarta and created v2 of this lib (External Uploader started using v2 when it was upgraded to Spring 6/jakarta). This was done in the hopes that AB would work with the jakarta namespace in the near future. 
Until that happened, AB would use a version of this library off a specific v1 branch and would have to be built manually instead of using the Jenkins job to publish to artifactory.
Since we now know that's not going to happen anytime soon, I've made some changes so that v2 of this works both with javax and jakarta namespaces, by adding annotations with both namespaces. It seems hacky but it works - I have tested it both on AB and External Uploader.
This way, going forward we won't have to worry about having different branches and build methods for v1 and v2.

