### PR TITLE
ABC-8972 Make the XML name annotation match the variable name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@ Asset Bank REST API Representations
 
 POJOs used to transfer data to/from Asset Bank via its REST API.
 
+Important
+---------
+
+It seems the annotations naming the variables in the response doesn't work as expected.
+
+```Java
+  @XmlElementWrapper
+  @XmlElement(name = "attributes")
+  public List<AttributeValueRepr> attributes;
+```
+
+The XML ignore this name. Until Novemeber 2024 the JSON also ignored this name. 
+Now the JSON does use this name. Do not rename any variables or these annotations without testing both XML and JSON formats.
+
 Prerequisites
 -------------
 

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetEntityRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetEntityRepr.java
@@ -16,7 +16,7 @@ public class AssetEntityRepr extends LightweightAssetEntityRepr {
   public String excludedFileFormats;
 
   @XmlElementWrapper
-  @XmlElement(name = "allowableAttribute")
+  @XmlElement(name = "allowableAttributes")
   public List<AssetEntityAttributeRepr> allowableAttributes;
   public boolean showAttributeLabels;
   public URL matchOnAttributeUrl;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/AssetRepr.java
@@ -28,7 +28,7 @@ public class AssetRepr {
   public URL unwatermarkedLargeImageUrl;
 
   @XmlElementWrapper
-  @XmlElement(name = "attribute")
+  @XmlElement(name = "attributes")
   public List<AttributeValueRepr> attributes;
 
   @SuppressWarnings("unused") // needed to keep JAXB happy

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/BatchContentUrlRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/BatchContentUrlRepr.java
@@ -8,7 +8,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "assetContentUrls")
 public class BatchContentUrlRepr {
   @XmlElementWrapper
-  @XmlElement(name = "contentUrl")
+  @XmlElement(name = "contentUrls")
   public List<AssetContentUrlRepr> contentUrls;
 
   public BatchContentUrlRepr() {

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/CategoryRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/CategoryRepr.java
@@ -18,7 +18,7 @@ public class CategoryRepr {
   public URL parent;
 
   @XmlElementWrapper
-  @XmlElement(name = "category")
+  @XmlElement(name = "children")
   public Collection<CategoryRepr> children;
 
   public CategoryRepr() {

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/CreateAssetRequestRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/CreateAssetRequestRepr.java
@@ -18,7 +18,7 @@ public class CreateAssetRequestRepr {
   public URL assetTypeUrl;
 
   @XmlElementWrapper
-  @XmlElement(name = "accessLevel")
+  @XmlElement(name = "accessLevels")
   public List<FolderRepr> accessLevels;
 
   public CreateAssetRequestRepr(List<FolderRepr> accessLevels) {

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/DisplayAttributeGroupRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/DisplayAttributeGroupRepr.java
@@ -12,7 +12,7 @@ public class DisplayAttributeGroupRepr {
   public URL url;
 
   @XmlElementWrapper
-  @XmlElement(name = "attribute")
+  @XmlElement(name = "attributes")
   public List<AttributeRepr> attributes;
   public String name = null;
   public long id;

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/FolderRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/FolderRepr.java
@@ -24,7 +24,7 @@ public class FolderRepr {
   public boolean showPromotedItems;
   public boolean showRecentItems;
   @XmlElementWrapper
-  @XmlElement(name = "accessLevel")
+  @XmlElement(name = "children")
   public Collection<FolderRepr> children;
 
   public FolderRepr() {

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/KeywordRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/KeywordRepr.java
@@ -20,7 +20,7 @@ public class KeywordRepr {
   public URL parent;
 
   @XmlElementWrapper
-  @XmlElement(name = "keyword")
+  @XmlElement(name = "children")
   public Collection<KeywordRepr> children;
 
   public KeywordRepr() {

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightweightAssetRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/LightweightAssetRepr.java
@@ -23,11 +23,11 @@ public class LightweightAssetRepr {
   public String accessLevelIds;
 
   @XmlElementWrapper
-  @XmlElement(name = "displayAttribute")
+  @XmlElement(name = "displayAttributes")
   public List<DisplayAttributeRepr> displayAttributes = new ArrayList<>();
 
   @XmlElementWrapper
-  @XmlElement(name = "attribute")
+  @XmlElement(name = "attributes")
   public List<SearchAttributeValueRepr> attributes;
 
   public LightweightAssetRepr() {

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/PublishingLogRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/PublishingLogRepr.java
@@ -17,7 +17,7 @@ public class PublishingLogRepr {
   }
 
   @XmlElementWrapper
-  @XmlElement(name = "event")
+  @XmlElement(name = "events")
   public List<PublishingEventRepr> events;
   public long nextStartSequence;
 }

--- a/src/main/java/com/brightinteractive/assetbank/restapi/representations/UserRepr.java
+++ b/src/main/java/com/brightinteractive/assetbank/restapi/representations/UserRepr.java
@@ -17,7 +17,7 @@ public class UserRepr {
   public String surname = null;
   public String emailAddress = null;
   @XmlElementWrapper
-  @XmlElement(name = "groupId")
+  @XmlElement(name = "groupIds")
   public Collection<Long> groupIds = null;
   public boolean isAdmin = false;
   public boolean isOrgUnitAdmin = false;


### PR DESCRIPTION
since the variable name is what has been appearing in the XML and JSON since forever but somehow now it's using the name from the annotation.